### PR TITLE
Add support for secureProtocol()

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ This object is modeled after the `request` libraries options that are passed alo
 * `oauth` (`Object`) - See `Request.oauth()` below.
 * `hawk` (`Object`) - See `Request.hawk()` below
 * `strictSSL` (`Boolean`) - Default `true`; See `Request.strictSSL()` below.
+* `secureProtocol` (`String`) - See `Request.secureProtocol()` below.
 * `jar` (`Boolean` | `Jar`) - See `Request.jar()` below.
 * `aws` (`Object`) - See `Request.aws()` below.
 * `httpSignature` (`Object`) - See `Request.httpSignature()` Below.
@@ -479,6 +480,18 @@ Sets `proxy`, HTTP Proxy to be set on `Request.options` based on value.
 ```js
 Request.proxy('http://localproxy.com');
 ```
+
+#### Request.secureProtocol(String)
+
+Sets the secure protocol to use:
+
+```js
+Request.secureProtocol('SSLv2_method');
+// or 
+Request.secureProtocol('SSLv3_client_method');
+```
+
+See [openssl.org](https://www.openssl.org/docs/ssl/SSL_CTX_new.html) for all possible values.
 
 #### Request.aws(Object)
 

--- a/index.js
+++ b/index.js
@@ -729,7 +729,7 @@ Unirest.enum = {
   options: [ 
     'uri:url', 'redirects:maxRedirects', 'redirect:followRedirect', 'url', 'method', 'qs', 'form', 'json', 'multipart', 
     'followRedirect', 'followAllRedirects', 'maxRedirects', 'encoding', 'pool', 'timeout', 'proxy', 'oauth', 'hawk', 
-    'ssl:strictSSL', 'strictSSL', 'jar', 'cookies:jar', 'aws', 'httpSignature', 'localAddress', 'ip:localAddress' 
+    'ssl:strictSSL', 'strictSSL', 'jar', 'cookies:jar', 'aws', 'httpSignature', 'localAddress', 'ip:localAddress', 'secureProtocol'
   ]
 };
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "mime": "~1.2.11",
-    "request": "~2.27.0",
+    "request": "~2.33.0",
     "should": "~2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds support for `secureProtocol('...')`, which is provided by the `https` module.

_Note:_ bumped up `Request` to version 2.33.0 (2.27 didn't have support yet).
