### PR TITLE
[BUG] Crash when server does not return Content-Type header

### DIFF
--- a/index.js
+++ b/index.js
@@ -403,7 +403,7 @@ Unirest = function (method, uri, headers, body, callback) {
           // Handle Response Body
           
           if (body) {
-            type = Unirest.type(result.headers['content-type'], true);
+            type = result.headers['content-type'] ? Unirest.type(result.headers['content-type'], true) : false;
             if (type) data = Unirest.Response.parse(body, type);
             else data = body;
           }


### PR DESCRIPTION
Code should not assume every server always returns content-type.

W/o the patch method Unirest.type crashes with the following error:

`TypeError: Cannot call method 'split' of undefined`
