### PR TITLE
Support forever-agent option

### DIFF
--- a/index.js
+++ b/index.js
@@ -842,7 +842,7 @@ Unirest.enum = {
   options: [
     'uri:url', 'redirects:maxRedirects', 'redirect:followRedirect', 'url', 'method', 'qs', 'form', 'json', 'multipart',
     'followRedirect', 'followAllRedirects', 'maxRedirects', 'encoding', 'pool', 'timeout', 'proxy', 'oauth', 'hawk',
-    'ssl:strictSSL', 'strictSSL', 'jar', 'cookies:jar', 'aws', 'httpSignature', 'localAddress', 'ip:localAddress', 'secureProtocol'
+    'ssl:strictSSL', 'strictSSL', 'jar', 'cookies:jar', 'aws', 'httpSignature', 'localAddress', 'ip:localAddress', 'secureProtocol', 'forever'
   ]
 };
 


### PR DESCRIPTION
Add forever-agent to `request` module options (https://github.com/request/request/blob/master/request.js#L632).

 So people could do `request.forever true` to use `forever-agent` in the request. 
