### PR TITLE
Fix undefined multipart form data error

### DIFF
--- a/index.js
+++ b/index.js
@@ -642,7 +642,7 @@ Unirest = function (method, uri, headers, body, callback) {
             if (serialized = handleFieldValue(value[i]))
               $this.rawField(name, serialized, options);
           }
-        } else {
+        } else if (value !== null && value !== undefined) {
           $this.rawField(name, handleFieldValue(value), options);
         }
       }

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -123,7 +123,8 @@ describe('Unirest', function () {
       var file = __dirname + '/../README.md';
       var data = {
         a: 'foo',
-        b: 'bar'
+        b: 'bar',
+        c: undefined
       };
 
       request.attach('u', file);


### PR DESCRIPTION
Creating a multipart call with an undefined parameter value made Unirest calling toString() or other properties while building the request (as in `handleFieldValue()`).
