### PR TITLE
Fix Multipart form data requests fail with port number

### DIFF
--- a/index.js
+++ b/index.js
@@ -525,6 +525,11 @@ Unirest = function (method, uri, headers, body, callback) {
 
         if ($this._multipart.length && !$this._stream) {
           parts = URL.parse($this.options.url);
+          //URL.parse will include the port number in the
+          //host information. FormData doesn't expect this
+          //URL parse will include port information in parts.port
+          parts.host = parts.host.replace(parts.host.match(/:\d+/), '');
+
           form = new FormData();
 
           if (header = $this.options.headers[$this.hasHeader('content-type')]) {

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -142,6 +142,28 @@ describe('Unirest', function () {
       });
     });
 
+    it('should correctly post MULTIFORM data with port number', function (done) {
+      var request = unirest.post('http://httpbin.org:80/post');
+      var file = __dirname + '/../README.md';
+      var data = {
+        a: 'foo',
+        b: 'bar',
+        c: undefined
+      };
+
+      request.attach('u', file);
+
+      for (var key in data) {
+        request.field(key, data[key]);
+      }
+
+      request.end(function (response) {
+        should(response.status).equal(200);
+        should(response.body.headers['Content-Type']).startWith('multipart/form-data');
+        done();
+      });
+    });
+
     it('should correctly post JSON data.', function (done) {
       var data = {
         is: 'unirest',


### PR DESCRIPTION
URL.parse parses the port information however it leaves the ':80' or whatever port number in the host name. FormData chokes on this because it doesn't expect that in the host field.

Added a regex to remove this from the the first occurrence in this in the host field. The port number should always be captured in the host field anyways. Added a unit test to cover this scenario.
