### PR TITLE
Fixes for example code using the header() and headers() functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You're probably wondering how by using **Unirest** makes creating requests easie
 
 ```js
 unirest.post('http://httpbin.org/post')
-.header('Accept': 'application/json')
+.header('Accept', 'application/json')
 .send({ "parameter": 23, "foo": "bar" })
 .end(function (response) {
   console.log(response.body);
@@ -40,7 +40,7 @@ Transferring file data has been simplified:
 
 ```js
 unirest.post('http://httpbin.org/post')
-.headers('Accept': 'application/json')
+.headers({'Accept': 'application/json'})
 .field('parameter', 'value') // Form field
 .attach('file', '/tmp/file') // Attachment
 .end(function (response) {
@@ -52,7 +52,7 @@ unirest.post('http://httpbin.org/post')
 
 ```js
 unirest.post('http://httpbin.org/post')
-.headers('Accept': 'application/json')
+.headers({'Accept': 'application/json'})
 .send(new Buffer([1,2,3]))
 .end(function (response) {
   console.log(response.body);

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ request module Superagent (which this library is modeled after slightly).
 ```js
 var Request = unirest.post('http://httpbin.org/post');
 
-Request.header('Accepts': 'application/json').end(function (response) {
+Request.header('Accept', 'application/json').end(function (response) {
   ...
 });
 ```
@@ -197,7 +197,7 @@ or `field` and `value` arguments. Each entry is then stored in a two locations, 
 
 ```js
 Request.headers({
-  'Accepts': 'application/json',
+  'Accept': 'application/json',
   'User-Agent': 'Unirest Node.js'
 })
 ```
@@ -207,7 +207,7 @@ Note the usage of [`Request.headers`](#requestheaders) which is simply an alias 
 **Arguments**
 
 ```js
-Request.header('Accepts', 'application/json');
+Request.header('Accept', 'application/json');
 ```
 
 #### Request.part(Object)
@@ -320,7 +320,7 @@ The following methods are sugar methods for attaching files, and form fields. In
 
 ```js
 unirest.post('http://httpbin.org/post')
-.header('Accept': 'application/json')
+.header('Accept', 'application/json')
 .field({
   'parameter': 'value'
 })
@@ -338,7 +338,7 @@ unirest.post('http://httpbin.org/post')
 
 ```js
 unirest.post('http://httpbin.org/post')
-.header('Accept': 'application/json')
+.header('Accept', 'application/json')
 .field('parameter', 'value') // Form field
 .attach('file', 'dog.png') // Attachment
 .attach('remote file', fs.createReadStream(path.join(__dirname, 'dog.png')))  // Same as above.


### PR DESCRIPTION
The header() function takes 2 parameters, the headers() function takes an object. Also I've fixed the examples which set an Accepts header, the header name should be Accept.