### PR TITLE
Added support for promise interface.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "bluebird": "^2.9.25",
     "form-data": "^0.2.0",
     "mime": "~1.2.11",
     "request": "~2.51.0"

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -25,6 +25,22 @@ describe('Unirest', function () {
       });
     });
 
+    it('should be able to call requests .then method to get a promise of the result.', function (done) {
+      unirest.get('http://mockbin.com/request').set('Accept', 'application/json').then(function (response) {
+        should(response.status).equal(200);
+        should(response.body).have.type('object');
+        done();
+      });
+    });
+
+    it('should be able to call alternative promise methods on a request.', function (done) {
+      unirest.get('http://mockbin.com/request').set('Accept', 'application/json').tap(function (response) {
+        should(response.status).equal(200);
+        should(response.body).have.type('object');
+        done();
+      });
+    });
+
     it('should correctly parse GZIPPED data.', function (done) {
       unirest.get('http://mockbin.com/gzip').set('Accept', 'gzip').end(function (response) {
         should(response.status).equal(200);


### PR DESCRIPTION
I like to use `unirest` as a library for making HTTP request, but I am missing the possibility to use it with a promise interface. This pull request adds such an interface, and I hope you will consider merging it. It allows users to continue the request chain as a promise chain, as an alternative to calling `.end()` (which of course continues working the way it did before).

As an alternative to including the promise interface by default, I offer the suggestion of adding in optionally, for instance by allowing people to `require('unirest/bluebird')`. Let me know if this alternative suits you more and I'll look into arranging that.

Some additional motivation: I think unirest's chaining interface works together beautifully with a promise chain. You can do stuff like this:

```js
unirest.post('http://mockbin.com/request')
.header('Accept', 'application/json')
.send({ "parameter": 23, "foo": "bar" })
.tap(function(response) {
  if (response.statusCode >= 400) {
    throw new RequestError(response);
  }
})
.get('body')
.then(console.log)
//and so on.
```

The guys from [knex.js](http://knexjs.org/) use a beautiful trick for seamlessly transitioning from a query chain to promise chain, which I implemented for unirest in this PR.