### PR TITLE
update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You're probably wondering how by using **Unirest** makes creating requests easie
 
 ```js
 unirest.post('http://mockbin.com/request')
-.header('Accept', 'application/json')
+.headers({'Accept': 'application/json', 'Content-Type': 'application/json'})
 .send({ "parameter": 23, "foo": "bar" })
 .end(function (response) {
   console.log(response.body);


### PR DESCRIPTION
Add content-type header for POST request with json data.

If no content type defined in the header, unirest set it as `application/x-www-form-urlencoded` by default.