### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Transferring file data has been simplified:
 
 ```js
 unirest.post('http://mockbin.com/request')
-.headers({'Accept': 'application/json'})
+.headers({'Accept': 'multipart/form-data'})
 .field('parameter', 'value') // Form field
 .attach('file', '/tmp/file') // Attachment
 .end(function (response) {

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Transferring file data has been simplified:
 
 ```js
 unirest.post('http://mockbin.com/request')
-.headers({'Accept': 'multipart/form-data'})
+.headers({'Content-Type': 'multipart/form-data'})
 .field('parameter', 'value') // Form field
 .attach('file', '/tmp/file') // Attachment
 .end(function (response) {


### PR DESCRIPTION
When you send a file or files, the header should be `multipart/form-data`. Or even remove the header part since you made Unirest smart enough to set the right header.