### PR TITLE
Ignore content-encoding for 204 responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -462,7 +462,7 @@ var Unirest = function (method, uri, headers, body, callback) {
         }
 
         function handleGZIPResponse (response) {
-          if (/^(deflate|gzip)$/.test(response.headers['content-encoding'])) {
+          if (response.statusCode !== 204 && /^(deflate|gzip)$/.test(response.headers['content-encoding'])) {
             var unzip = zlib.createUnzip();
             var stream = new Stream();
             var decoder, _on = response.on;

--- a/index.js
+++ b/index.js
@@ -462,9 +462,7 @@ var Unirest = function (method, uri, headers, body, callback) {
         }
 
         function handleGZIPResponse (response) {
-          var hasContent = response.body || response.headers['content-length'];
-
-          if (hasContent && /^(deflate|gzip)$/.test(response.headers['content-encoding'])) {
+          if (/^(deflate|gzip)$/.test(response.headers['content-encoding'])) {
             var unzip = zlib.createUnzip();
             var stream = new Stream();
             var decoder, _on = response.on;
@@ -474,6 +472,13 @@ var Unirest = function (method, uri, headers, body, callback) {
 
             // Make sure we emit prior to processing
             unzip.on('error', function (error) {
+              // Catch the parser error when there is no content
+              if (error.errno === zlib.Z_BUF_ERROR) {
+                stream.emit('end');
+
+                return;
+              }
+
               stream.emit('error', error);
             });
 

--- a/index.js
+++ b/index.js
@@ -462,7 +462,9 @@ var Unirest = function (method, uri, headers, body, callback) {
         }
 
         function handleGZIPResponse (response) {
-          if (response.statusCode !== 204 && /^(deflate|gzip)$/.test(response.headers['content-encoding'])) {
+          var hasContent = response.body || response.headers['content-length'];
+
+          if (hasContent && /^(deflate|gzip)$/.test(response.headers['content-encoding'])) {
             var unzip = zlib.createUnzip();
             var stream = new Stream();
             var decoder, _on = response.on;


### PR DESCRIPTION
Currently, if a 204 returns no data, but has `content-encoding` set to `gzip`, `zlib` throws an exception:

```
Error: unexpected end of file
    at Zlib._handle.onerror (zlib.js:363:17)
```

This causes it to skip the unzipping entirely.