### PR TITLE
.auth doesn't work together with .attach #80 fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ var Unirest = function (method, uri, headers, body, callback) {
       auth: function (user, password, sendImmediately) {
         $this.options.auth = (is(user).a(Object)) ? user : {
           user: user,
-          password: password,
+          pass: password,
           sendImmediately: sendImmediately
         }
 


### PR DESCRIPTION
The previous try didn't fix it fully https://github.com/Mashape/unirest-nodejs/pull/86
When use Request.auth(username, password, sendImmediately) notation, it was creating incorrect auth object, it was using 'password' instead of 'path'